### PR TITLE
이상윤 2025-08-02 Document 관련 CRUD API 과제 제출 

### DIFF
--- a/src/main/java/com/next/app/api/sangyoon/controller/DocumentController.java
+++ b/src/main/java/com/next/app/api/sangyoon/controller/DocumentController.java
@@ -1,0 +1,92 @@
+package com.next.app.api.sangyoon.controller;
+
+import com.next.app.api.sangyoon.entity.Document;
+import com.next.app.api.sangyoon.service.DocumentService;
+import com.next.app.exception.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/documents")
+@Tag(name = "Document Controller", description = "문서 관리 API")
+@CrossOrigin(origins = "http://localhost")
+public class DocumentController {
+
+    private final DocumentService documentService;
+
+    @GetMapping("/list")
+    @Operation(summary = "문서 전체목록 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "500", description = "기타오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public List<Document> getAllDocuments() {
+        return documentService.getAllDocuments();
+    }
+
+    @GetMapping("/list/{ownerId}")
+    @Operation(summary = "회원에 따른 전체목록 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "500", description = "기타오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public List<Document> getDocumentsByDocId(@PathVariable Long ownerId) {
+        return documentService.getDocumentsByDocId(ownerId);
+    }
+
+    @GetMapping("/single/{docId}")
+    @Operation(summary = "문서 상세 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "문서 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "기타오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<Document> getDocumentByDocId(@PathVariable Long docId) {
+        return ResponseEntity.ok(documentService.getDocumentByDocId(docId));
+    }
+
+    @PostMapping
+    @Operation(summary = "문서 등록")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "등록 성공"),
+            @ApiResponse(responseCode = "400", description = "경로 중복", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "기타오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public Document createDocument(@RequestBody Document document) {
+        return documentService.createDocument(document);
+    }
+
+    @PutMapping
+    @Operation(summary = "문서 수정")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400", description = "경로 중복", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "문서 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "기타오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public Document updateDocument(@RequestBody Document document) {
+        return documentService.updateDocument(document);
+    }
+
+    @DeleteMapping("/{docId}")
+    @Operation(summary = "문서 삭제")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "문서 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "기타오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public void deleteDocument(@PathVariable Long docId) {
+        documentService.deleteDocument(docId);
+    }
+
+}

--- a/src/main/java/com/next/app/api/sangyoon/controller/DocumentController.java
+++ b/src/main/java/com/next/app/api/sangyoon/controller/DocumentController.java
@@ -62,8 +62,8 @@ public class DocumentController {
             @ApiResponse(responseCode = "400", description = "경로 중복", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "500", description = "기타오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public Document createDocument(@RequestBody Document document) {
-        return documentService.createDocument(document);
+    public ResponseEntity<Document> createDocument(@RequestBody Document document) {
+        return ResponseEntity.ok(documentService.createDocument(document));
     }
 
     @PutMapping
@@ -74,8 +74,8 @@ public class DocumentController {
             @ApiResponse(responseCode = "404", description = "문서 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "500", description = "기타오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public Document updateDocument(@RequestBody Document document) {
-        return documentService.updateDocument(document);
+    public ResponseEntity<Document> updateDocument(@RequestBody Document document) {
+        return ResponseEntity.ok(documentService.updateDocument(document));
     }
 
     @DeleteMapping("/{docId}")

--- a/src/main/java/com/next/app/api/sangyoon/entity/Document.java
+++ b/src/main/java/com/next/app/api/sangyoon/entity/Document.java
@@ -1,0 +1,33 @@
+package com.next.app.api.sangyoon.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "`documents`")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Document {
+    @Id
+    @Column(name = "`doc_id`")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long docId;
+
+    @Column(name = "`title`", length = 200, nullable = false)
+    private String title;
+
+    @Column(name = "`owner_id`", nullable = false)
+    private Long ownerId;
+
+    @Column(name = "`file_path`", nullable = false, unique = true)
+    private String filePath;
+
+    @Builder.Default
+    @Column(name = "`created_at`", nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+}

--- a/src/main/java/com/next/app/api/sangyoon/repository/DocumentRepository.java
+++ b/src/main/java/com/next/app/api/sangyoon/repository/DocumentRepository.java
@@ -1,0 +1,23 @@
+package com.next.app.api.sangyoon.repository;
+
+import com.next.app.api.sangyoon.entity.Document;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface DocumentRepository extends JpaRepository<Document, Long> {
+
+    List<Document> findByOwnerId(Long ownerId);
+
+    boolean existsByFilePath(String filePath);
+
+    // 더티 체킹 방지용
+    @Modifying
+    @Query("UPDATE Document d SET d.title = :#{#document.title}, d.ownerId = :#{#document.ownerId}, d.filePath = :#{#document.filePath} WHERE d.id = :#{#document.docId}")
+    int updateById(@Param("document") Document document);
+
+    int deleteByDocId(Long docId);
+}

--- a/src/main/java/com/next/app/api/sangyoon/service/DocumentService.java
+++ b/src/main/java/com/next/app/api/sangyoon/service/DocumentService.java
@@ -1,0 +1,58 @@
+package com.next.app.api.sangyoon.service;
+
+import com.next.app.api.sangyoon.entity.Document;
+import com.next.app.api.sangyoon.repository.DocumentRepository;
+import com.next.app.exception.DocumentException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DocumentService {
+
+    private final DocumentRepository documentRepository;
+
+    public List<Document> getAllDocuments() {
+        return documentRepository.findAll();
+    }
+
+    public List<Document> getDocumentsByDocId(Long ownerId) {
+        return documentRepository.findByOwnerId(ownerId);
+    }
+
+    public Document getDocumentByDocId(Long docId) {
+        return documentRepository.findById(docId)
+                .orElseThrow(() -> DocumentException.documentNotFound(docId));
+    }
+
+    @Transactional
+    public Document createDocument(Document document) {
+        if (documentRepository.existsByFilePath(document.getFilePath())) {
+            throw DocumentException.pathAlreadyExists(document.getFilePath());
+        }
+        return documentRepository.save(document);
+    }
+
+    @Transactional
+    public Document updateDocument(Document document) {
+        if (documentRepository.existsByFilePath(document.getFilePath())) {
+            throw DocumentException.pathAlreadyExists(document.getFilePath());
+        }
+        int updatedCount = documentRepository.updateById(document);
+        if (updatedCount == 0) {
+            throw DocumentException.documentNotFound(document.getDocId());
+        }
+        return document;
+    }
+
+    @Transactional
+    public void deleteDocument(Long docId) {
+        int deletedCount = documentRepository.deleteByDocId(docId);
+        if (deletedCount == 0) {
+            throw DocumentException.documentNotFound(docId);
+        }
+    }
+}

--- a/src/main/java/com/next/app/api/user/entity/Document.java
+++ b/src/main/java/com/next/app/api/user/entity/Document.java
@@ -1,4 +1,0 @@
-package com.next.app.api.user.entity;
-
-public class Document {
-}

--- a/src/main/java/com/next/app/api/user/entity/Document.java
+++ b/src/main/java/com/next/app/api/user/entity/Document.java
@@ -1,0 +1,4 @@
+package com.next.app.api.user.entity;
+
+public class Document {
+}

--- a/src/main/java/com/next/app/exception/DocumentException.java
+++ b/src/main/java/com/next/app/exception/DocumentException.java
@@ -1,0 +1,18 @@
+package com.next.app.exception;
+
+public class DocumentException extends BusinessException {
+
+
+    public DocumentException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    public static DocumentException pathAlreadyExists(String path) {
+        return new DocumentException(ErrorCode.BUSINESS_RULE_VIOLATION, "파일 경로 " + path + "는 이미 사용 중입니다.");
+    }
+
+    public static DocumentException documentNotFound(Long docId) {
+        return new DocumentException(ErrorCode.ORDER_NOT_FOUND, "문서 " + docId + "를 찾을 수 없습니다.");
+    }
+
+}


### PR DESCRIPTION
**1. 예외처리**

```
public class DocumentException extends BusinessException {


    public DocumentException(ErrorCode errorCode, String message) {
        super(errorCode, message);
    }

    public static DocumentException pathAlreadyExists(String path) {
        return new DocumentException(ErrorCode.BUSINESS_RULE_VIOLATION, "파일 경로 " + path + "는 이미 사용 중입니다.");
    }

    public static DocumentException documentNotFound(Long docId) {
        return new DocumentException(ErrorCode.ORDER_NOT_FOUND, "문서 " + docId + "를 찾을 수 없습니다.");
    }

}

```
```
@Getter
@RequiredArgsConstructor
public enum ErrorCode {
    
    // 공통 에러 (1000번대)
    INVALID_INPUT_VALUE(1000, "잘못된 입력값입니다."),
    METHOD_NOT_ALLOWED(1001, "지원하지 않는 HTTP 메서드입니다."),
    ENTITY_NOT_FOUND(1002, "요청한 리소스를 찾을 수 없습니다."),
    INTERNAL_SERVER_ERROR(1003, "서버 내부 오류가 발생했습니다."),
    INVALID_TYPE_VALUE(1004, "잘못된 타입의 값입니다."),
    HANDLE_ACCESS_DENIED(1005, "접근이 거부되었습니다."),
    
    // 사용자 관련 에러 (2000번대)
    USER_NOT_FOUND(2000, "사용자를 찾을 수 없습니다."),
    USER_ALREADY_EXISTS(2001, "이미 존재하는 사용자입니다."),
    USER_EMAIL_DUPLICATE(2002, "이미 사용 중인 이메일입니다."),
    USER_INVALID_PASSWORD(2003, "잘못된 비밀번호입니다."),
    USER_ACCOUNT_LOCKED(2004, "계정이 잠겨있습니다."),
    
    // 인증/인가 관련 에러 (3000번대)
    UNAUTHORIZED(3000, "인증이 필요합니다."),
    FORBIDDEN(3001, "권한이 없습니다."),
    TOKEN_EXPIRED(3002, "토큰이 만료되었습니다."),
    INVALID_TOKEN(3003, "유효하지 않은 토큰입니다."),
    
    // 비즈니스 로직 에러 (4000번대)
    BUSINESS_RULE_VIOLATION(4000, "비즈니스 규칙을 위반했습니다."),
    INSUFFICIENT_BALANCE(4001, "잔액이 부족합니다."),
    ORDER_NOT_FOUND(4002, "주문을 찾을 수 없습니다."),
    
    // 외부 서비스 에러 (5000번대)
    EXTERNAL_SERVICE_ERROR(5000, "외부 서비스 오류가 발생했습니다."),
    EXTERNAL_SERVICE_TIMEOUT(5001, "외부 서비스 응답 시간이 초과되었습니다.");
    
    private final int code;
    private final String message;
}
```
```
@Data
@Builder
public class ErrorResponse {
    
    private final LocalDateTime timestamp;
    private final int status;
    private final String error;
    private final int code;
    private final String message;
    private final String path;
    
    public static ErrorResponse of(ErrorCode errorCode, String path) {
        return ErrorResponse.builder()
                .timestamp(LocalDateTime.now())
                .status(errorCode.getCode() / 1000 * 100) // 에러 코드를 HTTP 상태 코드로 변환
                .error(errorCode.name())
                .code(errorCode.getCode())
                .message(errorCode.getMessage())
                .path(path)
                .build();
    }
    
    public static ErrorResponse of(ErrorCode errorCode, String message, String path) {
        return ErrorResponse.builder()
                .timestamp(LocalDateTime.now())
                .status(errorCode.getCode() / 1000 * 100)
                .error(errorCode.name())
                .code(errorCode.getCode())
                .message(message)
                .path(path)
                .build();
    }
} 
```

문서 관련 API에 맞는 예외 로직을 구현하였다. 공통 에러 반환 로직을 보았을 때 고유 에러 코드에 10 나눈 것을 HttpStatus로 치환한 것으로 보이고, 1000번대 오류를 사용할 경우 api가 응답을 안 하는 문제가 발생하여 최대한 상황에 맞는 ErrorCode를 사용하였다.

**2. 테이블 생성**

```
@Entity
@Table(name = "`documents`")
@Getter
@Builder
@NoArgsConstructor(access = AccessLevel.PROTECTED)
@AllArgsConstructor
public class Document {
    @Id
    @Column(name = "`doc_id`")
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long docId;

    @Column(name = "`title`", length = 200, nullable = false)
    private String title;

    @Column(name = "`owner_id`", nullable = false)
    private Long ownerId;

    @Column(name = "`file_path`", nullable = false, unique = true)
    private String filePath;

    @Builder.Default
    @Column(name = "`created_at`", nullable = false)
    private LocalDateTime createdAt = LocalDateTime.now();

}
```
요구 사항에 따라 파일 제목 글자 수 제한은 200자(length 를 설정하지 않을 경우 기본 값으로 225자를 사용할 수 있다.), 파일 경로는 중복 불가를 위해 unique 처리를 하였다. Setter을 사용하는 대신 요즘 유행하는 Builder 패턴을 사용하였다. 다만 Builder 패턴 사용 시 기본 값이 있는 변수에 아무것도 설정하지 않을 시 null을 반환하기 때문에  @Builder.Default 어노테이션을 사용해야 정상적으로 적용된다. 또한 외부에서 빈 객체를 생성할 수 없도록 @NoArgsConstructor(access = AccessLevel.PROTECTED) 빈 생성자의 접근 제어자를 protected로 설정한다.

**3. JPA Repository**

```
@Repository
public interface DocumentRepository extends JpaRepository<Document, Long> {

    List<Document> findByOwnerId(Long ownerId);

    boolean existsByFilePath(String filePath);

    // 더티 체킹 방지용
    @Modifying
    @Query("UPDATE Document d SET d.title = :#{#document.title}, d.ownerId = :#{#document.ownerId}, d.filePath = :#{#document.filePath} WHERE d.id = :#{#document.docId}")
    int updateById(@Param("document") Document document);

    int deleteByDocId(Long docId);
}
```
List<Document> findByOwnerId(Long ownerId)
→ 특정 소유자 ID(ownerId)에 해당하는 문서 리스트를 조회하는 기능이다. 이는 문서 목록을 사용자 단위로 필터링할 때 활용된다.

boolean existsByFilePath(String filePath)
→ 특정 파일 경로가 이미 존재하는지 여부를 판단하기 위한 메서드로, 파일 경로 중복을 사전에 방지하기 위한 용도로 사용된다.

updateById(Document document)
→ JPA의 더티 체킹을 피하기 위해 명시적으로 JPQL을 작성하여 업데이트를 수행한다. 이 방식은 불필요한 엔티티 조회를 줄여 성능상 이점이 있으며, 단일 쿼리로 직접 수정이 가능하다. 단, @Transactional이 반드시 함께 적용되어야 실행된다.
주의할 점은 SQL 문법이 컬럼명으로 들어갈 시 Native Query 방식을 사용하게 되는데 이 경우 객체를 받아서 SQL 구문을 작성하는게 불가능해지고 직접 들어갈 인자를 집어넣어줘야 된다.

int deleteByDocId(Long docId)
→ docId를 기준으로 문서를 삭제한다. void 타입으로 아무것도 반환하지 않는 deleteById() 메서드 대신, 삭제된 숫자를 반환하여 삭제가 되지 않을 경우 오류로 인식시키기 위해 작성하였다.

**4.Service**

```
@Service
@RequiredArgsConstructor
public class DocumentService {

    private final DocumentRepository documentRepository;

    public List<Document> getAllDocuments() {
        return documentRepository.findAll();
    }

    public List<Document> getDocumentsByDocId(Long ownerId) {
        return documentRepository.findByOwnerId(ownerId);
    }

    public Document getDocumentByDocId(Long docId) {
        return documentRepository.findById(docId)
                .orElseThrow(() -> DocumentException.documentNotFound(docId));
    }

    @Transactional
    public Document createDocument(Document document) {
        if (documentRepository.existsByFilePath(document.getFilePath())) {
            throw DocumentException.pathAlreadyExists(document.getFilePath());
        }
        return documentRepository.save(document);
    }

    @Transactional
    public Document updateDocument(Document document) {
        if (documentRepository.existsByFilePath(document.getFilePath())) {
            throw DocumentException.pathAlreadyExists(document.getFilePath());
        }
        int updatedCount = documentRepository.updateById(document);
        if (updatedCount == 0) {
            throw DocumentException.documentNotFound(document.getDocId());
        }
        return document;
    }

    @Transactional
    public void deleteDocument(Long docId) {
        int deletedCount = documentRepository.deleteByDocId(docId);
        if (deletedCount == 0) {
            throw DocumentException.documentNotFound(docId);
        }
    }
}
```
기본적으로 JPQL NATIVE SQL이 사용되지 않고 기본 메서드가 단건으로 사용되었다면 JPA 내부에서 트랜젝선 처리가 되지만 만약의 상황을 대비하기 위해 Insert, Update, Delete 로직이 사용된 Service 메서드에는 @Transactional 어노테이션을 사용하는 것이 좋다.
오류 반환 로직을 Service에서 진행하여 Controller을 슬림하게 유지할 수 있고 예외처리의 책임을 Service가 온전히 맡게할 수 있다.

**4.Controller**

```
@RestController
@RequiredArgsConstructor
@RequestMapping("/api/documents")
@Tag(name = "Document Controller", description = "문서 관리 API")
@CrossOrigin(origins = "http://localhost")
public class DocumentController {

    private final DocumentService documentService;

    @GetMapping("/list")
    @Operation(summary = "문서 전체목록 조회")
    @ApiResponses(value = {
            @ApiResponse(responseCode = "200", description = "조회 성공"),
            @ApiResponse(responseCode = "500", description = "기타오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
    })
    public List<Document> getAllDocuments() {
        return documentService.getAllDocuments();
    }

    @GetMapping("/list/{ownerId}")
    @Operation(summary = "회원에 따른 전체목록 조회")
    @ApiResponses(value = {
            @ApiResponse(responseCode = "200", description = "조회 성공"),
            @ApiResponse(responseCode = "500", description = "기타오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
    })
    public List<Document> getDocumentsByDocId(@PathVariable Long ownerId) {
        return documentService.getDocumentsByDocId(ownerId);
    }

    @GetMapping("/single/{docId}")
    @Operation(summary = "문서 상세 조회")
    @ApiResponses(value = {
            @ApiResponse(responseCode = "200", description = "조회 성공"),
            @ApiResponse(responseCode = "404", description = "문서 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
            @ApiResponse(responseCode = "500", description = "기타오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
    })
    public ResponseEntity<Document> getDocumentByDocId(@PathVariable Long docId) {
        return ResponseEntity.ok(documentService.getDocumentByDocId(docId));
    }

    @PostMapping
    @Operation(summary = "문서 등록")
    @ApiResponses(value = {
            @ApiResponse(responseCode = "200", description = "등록 성공"),
            @ApiResponse(responseCode = "400", description = "경로 중복", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
            @ApiResponse(responseCode = "500", description = "기타오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
    })
    public Document createDocument(@RequestBody Document document) {
        return documentService.createDocument(document);
    }

    @PutMapping
    @Operation(summary = "문서 수정")
    @ApiResponses(value = {
            @ApiResponse(responseCode = "200", description = "수정 성공"),
            @ApiResponse(responseCode = "400", description = "경로 중복", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
            @ApiResponse(responseCode = "404", description = "문서 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
            @ApiResponse(responseCode = "500", description = "기타오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
    })
    public Document updateDocument(@RequestBody Document document) {
        return documentService.updateDocument(document);
    }

    @DeleteMapping("/{docId}")
    @Operation(summary = "문서 삭제")
    @ApiResponses(value = {
            @ApiResponse(responseCode = "200", description = "삭제 성공"),
            @ApiResponse(responseCode = "404", description = "문서 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
            @ApiResponse(responseCode = "500", description = "기타오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
    })
    public void deleteDocument(@PathVariable Long docId) {
        documentService.deleteDocument(docId);
    }

}
```
예외 처리를 Service에서 진행하였기 때문에 Controller 로직은 슬림하게 만들 수 있었다. 다만 Swagger을 위해 반환타입에 대한 설명을 달아놓았다. 앞서 예외처리에서 말했다 시피 고유 코드 숫자를 10으로 나누어 Http Status로 치환하였기 때문에 예시에 있는 반환 결과와 실제 보여지는 반환 결과가 다를 수 있다.